### PR TITLE
Add missing functions (first, second, third)

### DIFF
--- a/color-tools.el
+++ b/color-tools.el
@@ -22,6 +22,10 @@
 (require 'dash)
 (require 'fn)
 
+(defalias 'first 'car)
+(defalias 'second 'cadr)
+(defalias 'third 'caddr)
+
 (defcustom ct/always-shorten t
   "Whether results of color functions should ensure format #HHHHHH rather than #HHHHHHHHHHHH."
   :type 'boolean
@@ -30,35 +34,35 @@
 (defun ct/shorten (color)
   "Optionally transform COLOR #HHHHHHHHHHHH to #HHHHHH"
   (if (= (length color) 7)
-    color
-    (-as-> color C
-      (color-name-to-rgb C)
-      `(color-rgb-to-hex ,@C 2)
-      (eval C))))
+	color
+	(-as-> color C
+	  (color-name-to-rgb C)
+	  `(color-rgb-to-hex ,@C 2)
+	  (eval C))))
 
 (defun ct/maybe-shorten (color)
   "Internal function -- see ct/always-shorten"
   (if ct/always-shorten
-    (ct/shorten color)
-    color))
+	(ct/shorten color)
+	color))
 
 (defun ct/name-to-lab (name &optional white-point)
   "Transform NAME into LAB colorspace with some lighting assumption."
   (-as-> name <>
-    (color-name-to-rgb <>)
-    (apply 'color-srgb-to-xyz <>)
-    (append <> (list (or white-point color-d65-xyz)))
-    (apply 'color-xyz-to-lab <>)))
+	(color-name-to-rgb <>)
+	(apply 'color-srgb-to-xyz <>)
+	(append <> (list (or white-point color-d65-xyz)))
+	(apply 'color-xyz-to-lab <>)))
 
 (defun ct/lab-to-name (lab &optional white-point)
   "Convert LAB color to name"
   (->> (append lab (list (or white-point color-d65-xyz)))
-    (apply 'color-lab-to-xyz)
-    (apply 'color-xyz-to-srgb)
-    ;; when pulling it out we might die
-    (-map 'color-clamp)
-    (apply 'color-rgb-to-hex)
-    (ct/maybe-shorten)))
+	(apply 'color-lab-to-xyz)
+	(apply 'color-xyz-to-srgb)
+	;; when pulling it out we might die
+	(-map 'color-clamp)
+	(apply 'color-rgb-to-hex)
+	(ct/maybe-shorten)))
 
 (defun ct/is-light-p (name &optional scale )
   (> (first (ct/name-to-lab name)) (or scale 65)))
@@ -66,27 +70,27 @@
 (defun ct/greaten (percent color)
   "Make a light color lighter, a dark color darker"
   (ct/shorten
-    (if (ct/is-light-p color)
-      (color-lighten-name color percent)
-      (color-darken-name color percent))))
+	(if (ct/is-light-p color)
+	  (color-lighten-name color percent)
+	  (color-darken-name color percent))))
 
 (defun ct/lessen (percent color)
   "Make a light color darker, a dark color lighter"
   (ct/shorten
-    (if (ct/is-light-p color)
-      (color-darken-name color percent)
-      (color-lighten-name color percent))))
+	(if (ct/is-light-p color)
+	  (color-darken-name color percent)
+	  (color-lighten-name color percent))))
 
 (defun ct/iterations (start op condition)
   "Do OP on START color until CONDITION is met or op has no effect - return all intermediate steps."
   (let ((colors (list start))
-         (iterations 0))
-    (while (and (not (funcall condition (-last-item colors)))
-             (not (string= (funcall op (-last-item colors)) (-last-item colors)))
-             (< iterations 10000))
-      (setq iterations (+ iterations 1))
-      (setq colors (-snoc colors (funcall op (-last-item colors)))))
-    colors))
+		 (iterations 0))
+	(while (and (not (funcall condition (-last-item colors)))
+			 (not (string= (funcall op (-last-item colors)) (-last-item colors)))
+			 (< iterations 10000))
+	  (setq iterations (+ iterations 1))
+	  (setq colors (-snoc colors (funcall op (-last-item colors)))))
+	colors))
 
 (defun ct/iterate (start op condition)
   "Do OP on START color until CONDITION is met or op has no effect."
@@ -94,30 +98,30 @@
 
 (defun ct/tint-ratio (c against ratio)
   (ct/iterate c
-    (if (ct/is-light-p against)
-      (fn (ct/lab-darken <> 0.5))
-      (fn (ct/lab-lighten <> 0.5)))
-    (fn (> (ct/contrast-ratio <> against) ratio))))
+	(if (ct/is-light-p against)
+	  (fn (ct/lab-darken <> 0.5))
+	  (fn (ct/lab-lighten <> 0.5)))
+	(fn (> (ct/contrast-ratio <> against) ratio))))
 
 (defun ct/luminance-srgb (color)
   ;; cf https://www.w3.org/TR/2008/REC-WCAG20-20081211/#relativeluminancedef
   (let ((rgb (-map
-               (lambda (part)
-                 (if (<= part 0.03928)
-                   (/ part 12.92)
-                   (expt (/ (+ 0.055 part) 1.055) 2.4)))
-               (color-name-to-rgb color))))
-    (+
-      (* (nth 0 rgb) 0.2126)
-      (* (nth 1 rgb) 0.7152)
-      (* (nth 2 rgb) 0.0722))))
+			   (lambda (part)
+				 (if (<= part 0.03928)
+				   (/ part 12.92)
+				   (expt (/ (+ 0.055 part) 1.055) 2.4)))
+			   (color-name-to-rgb color))))
+	(+
+	  (* (nth 0 rgb) 0.2126)
+	  (* (nth 1 rgb) 0.7152)
+	  (* (nth 2 rgb) 0.0722))))
 
 (defun ct/contrast-ratio (c1 c2)
   ;; cf https://peteroupc.github.io/colorgen.html#Contrast_Between_Two_Colors
   (let ((rl1 (ct/luminance-srgb c1))
-         (rl2 (ct/luminance-srgb c2)))
-    (/ (+ 0.05 (max rl1 rl2))
-      (+ 0.05 (min rl1 rl2)))))
+		 (rl2 (ct/luminance-srgb c2)))
+	(/ (+ 0.05 (max rl1 rl2))
+	  (+ 0.05 (min rl1 rl2)))))
 
 (defun ct/lab-change-whitepoint (name w1 w2)
   "convert a color wrt white points W1 and W2 through the lab colorspace"
@@ -133,68 +137,68 @@
 (defun ct/transform-lab (color transform)
   "Work with a color in the LAB space. Ranges for LAB are 0-100, -100 -> 100, -100 -> 100"
   (->> color
-    (ct/name-to-lab)
-    (apply transform)
-    (ct/lab-to-name)))
+	(ct/name-to-lab)
+	(apply transform)
+	(ct/lab-to-name)))
 
 (defun ct/transform-lch (c transform)
   "Perform a transformation in the LAB LCH space. LCH values are {0-100, 0-100, 0-360}"
   ;; color-lab-to-lch returns a form with H in radians.
   ;; we do some hamfisted handling here for a consistent expectation.
   (ct/transform-lab c
-    (lambda (L A B)
-      (apply 'color-lch-to-lab
-        (let ((result (apply transform
-                        (append
-                          (-take 2 (color-lab-to-lch L A B))
-                          (list (radians-to-degrees (third (color-lab-to-lch L A B))))))))
-          (append
-            ;; (-map (lambda (p) (* 100.0 p)) (-take 2 result))
-            (-take 2 result)
-            (list (degrees-to-radians (mod (third result) 360.0)))))))))
+	(lambda (L A B)
+	  (apply 'color-lch-to-lab
+		(let ((result (apply transform
+						(append
+						  (-take 2 (color-lab-to-lch L A B))
+						  (list (radians-to-degrees (third (color-lab-to-lch L A B))))))))
+		  (append
+			;; (-map (lambda (p) (* 100.0 p)) (-take 2 result))
+			(-take 2 result)
+			(list (degrees-to-radians (mod (third result) 360.0)))))))))
 
 (defun ct/transform-hsl (c transform)
   "Tweak C in the HSL colorspace. Transform gets HSL in values {0-360,0-100,0-100}"
   (->> (color-name-to-rgb c)
-    (apply 'color-rgb-to-hsl)
-    ((lambda (hsl)
-       (apply transform
-         (list
-           (* 360.0 (first hsl))
-           (* 100.0 (second hsl))
-           (* 100.0 (third hsl))))))
-    ;; from transformed to what color.el expects
-    ((lambda (hsl)
-       (list
-         (/ (mod (first hsl) 360) 360.0)
-         (/ (second hsl) 100.0)
-         (/ (third hsl) 100.0))))
-    (-map 'color-clamp)
-    (apply 'color-hsl-to-rgb)
-    (apply 'color-rgb-to-hex)
-    (ct/maybe-shorten)))
+	(apply 'color-rgb-to-hsl)
+	((lambda (hsl)
+	   (apply transform
+		 (list
+		   (* 360.0 (first hsl))
+		   (* 100.0 (second hsl))
+		   (* 100.0 (third hsl))))))
+	;; from transformed to what color.el expects
+	((lambda (hsl)
+	   (list
+		 (/ (mod (first hsl) 360) 360.0)
+		 (/ (second hsl) 100.0)
+		 (/ (third hsl) 100.0))))
+	(-map 'color-clamp)
+	(apply 'color-hsl-to-rgb)
+	(apply 'color-rgb-to-hex)
+	(ct/maybe-shorten)))
 
 (defun ct/transform-hsluv (c transform)
   "Tweak a color in the HSLuv space. S,L range is {0-100}"
   (ct/maybe-shorten
-    (apply 'color-rgb-to-hex
-      (-map 'color-clamp
-        (hsluv-hsluv-to-rgb
-          (let ((result (apply transform (-> c ct/shorten hsluv-hex-to-hsluv))))
-            (list
-              (mod (first result) 360.0)
-              (second result)
-              (third result))))))))
+	(apply 'color-rgb-to-hex
+	  (-map 'color-clamp
+		(hsluv-hsluv-to-rgb
+		  (let ((result (apply transform (-> c ct/shorten hsluv-hex-to-hsluv))))
+			(list
+			  (mod (first result) 360.0)
+			  (second result)
+			  (third result))))))))
 
 ;; individual property tweaks:
 (defmacro ct/transform-prop (transform index)
   `(,transform c
-     (lambda (&rest args)
-       (-replace-at ,index
-         (if (functionp func)
-           (funcall func (nth ,index args))
-           func)
-         args))))
+	 (lambda (&rest args)
+	   (-replace-at ,index
+		 (if (functionp func)
+		   (funcall func (nth ,index args))
+		   func)
+		 args))))
 
 (defun ct/transform-hsl-h (c func) (ct/transform-prop ct/transform-hsl 0))
 (defun ct/transform-hsl-s (c func) (ct/transform-prop ct/transform-hsl 1))
@@ -214,12 +218,12 @@
 
 (defun ct/getter (c transform getter)
   (let ((return))
-    (apply transform
-      (list c
-        (lambda (&rest _)
-          (setq return (funcall getter _))
-          _)))
-    return))
+	(apply transform
+	  (list c
+		(lambda (&rest _)
+		  (setq return (funcall getter _))
+		  _)))
+	return))
 
 (defun ct/get-lab (c) (ct/getter c 'ct/transform-lab 'identity))
 (defun ct/get-lab-l (c) (ct/getter c 'ct/transform-lab 'first))
@@ -254,35 +258,35 @@
   ;; pastel colors belong to a pale family of colors, which, when described in the HSV color space,
   ;; have high value and low saturation.
   (ct/transform-hsl c
-    (lambda (H S L)
-      (list
-        H
-        (* S (or Smod 0.9))
-        (* L (or Vmod 1.1))))))
+	(lambda (H S L)
+	  (list
+		H
+		(* S (or Smod 0.9))
+		(* L (or Vmod 1.1))))))
 
 (defun ct/gradient (step start end &optional with-ends)
   "Create a gradient length STEP from START to END, optionally including START and END"
   (if with-ends
-    `(,start
-       ,@(-map
-           (fn (eval `(color-rgb-to-hex ,@<> 2)))
-           (color-gradient
-             (color-name-to-rgb start)
-             (color-name-to-rgb end)
-             (- step 2)))
-       ,end)
-    (-map
-      (fn (eval `(color-rgb-to-hex ,@<> 2)))
-      (color-gradient
-        (color-name-to-rgb start)
-        (color-name-to-rgb end)
-        step))))
+	`(,start
+	   ,@(-map
+		   (fn (eval `(color-rgb-to-hex ,@<> 2)))
+		   (color-gradient
+			 (color-name-to-rgb start)
+			 (color-name-to-rgb end)
+			 (- step 2)))
+	   ,end)
+	(-map
+	  (fn (eval `(color-rgb-to-hex ,@<> 2)))
+	  (color-gradient
+		(color-name-to-rgb start)
+		(color-name-to-rgb end)
+		step))))
 
 ;; make colors within our normalized transform functions:
 (defun ct/make-color-meta (transform properties)
   (apply transform
-    (list "#cccccc"                     ; throwaway
-      (lambda (&rest _) properties))))
+	(list "#cccccc"                     ; throwaway
+	  (lambda (&rest _) properties))))
 
 (defun ct/make-hsl (H S L) (ct/make-color-meta 'ct/transform-hsl (list H S L)))
 (defun ct/make-hsluv (H S L) (ct/make-color-meta 'ct/transform-hsluv (list H S L)))
@@ -292,12 +296,12 @@
 (defun ct/rotation-hsluv (c interval)
   "perform a hue rotation in the HSLuv color space"
   (-map (lambda (offset) (ct/transform-hsluv-h c (-partial '+ offset)))
-    (number-sequence 0 359 interval)))
+	(number-sequence 0 359 interval)))
 
 (defun ct/rotation-hsl (c interval)
   "perform a hue rotation in the HSLuv color space"
   (-map (lambda (offset) (ct/transform-hsl-h c (-partial '+ offset)))
-    (number-sequence 0 359 interval)))
+	(number-sequence 0 359 interval)))
 
 (defun ct/rotation-lch (c interval)
   "perform a hue rotation in the HSLuv color space"


### PR DESCRIPTION
When trying to use this version of the file Emacs search for the functions first, second and third.
Defining them using defalias fix it.